### PR TITLE
Fix example so that it implements interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1650,7 +1650,7 @@ interface AnimalOperation {
 ```
 Then we have our implementations for the animals
 ```php
-class Monkey {
+class Monkey implements Animal {
     
     public function shout() {
         echo 'Ooh oo aa aa!';
@@ -1661,7 +1661,7 @@ class Monkey {
     }
 }
 
-class Lion {
+class Lion implements Animal {
     public function roar() {
         echo 'Roaaar!';
     }
@@ -1671,7 +1671,7 @@ class Lion {
     }
 }
 
-class Dolphin {
+class Dolphin implements Animal {
     public function speak() {
         echo 'Tuut tuttu tuutt!';
     }


### PR DESCRIPTION
In Programmatic example of **Visitor** Pattern, `Monkey`, `Lion`, and `Dolphin` classes need to implement the `Animal` interface.