### PR TITLE
Remove docblocks from code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,10 +1333,8 @@ use Countable;
 use Iterator;
 
 class StationList implements Countable, Iterator {
-    /** @var RadioStation[] $stations */
     protected $stations = [];
     
-    /** @var int $counter */
     protected $counter;
     
     public function addStation(RadioStation $station) {


### PR DESCRIPTION
To unify all code samples, we'll remove the docblocks in this one.