### PR TITLE
Fixing the example of Singleton pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,13 +475,12 @@ final class President {
         // Hide the constructor
     }
     
-    public static function getInstance() : President {
-        if ($this->instance) {
-            return $this->instance;
+    public static function getInstance() : self {
+        if (!self::$instance) {
+            self::$instance = new self();
         }
         
-        $this->instance = new President();
-        return $this->instance;
+        return self::$instance;
     }
     
     private function __clone() {


### PR DESCRIPTION
* We have use self::$instance instead $this->instance because $instance is a static property.
* Instead of hard code the class name on return type hinting and when creating new instance, we can use self()