### PR TITLE
Fix typo in template method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1951,7 +1951,7 @@ abstract class Builder {
     
     public abstract function test();
     public abstract function lint();
-    public abstract function build();
+    public abstract function assemble();
     public abstract function deploy();
 }
 ```


### PR DESCRIPTION
The abstract class in the template method pattern had two declarations of `build()` and was missing the one for `assemble()` due to a typo.