### PR TITLE
add missing interface to Mediator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1616,6 +1616,11 @@ Here is the simplest example of a chat room (i.e. mediator) with users (i.e. col
 First of all, we have the mediator i.e. the chat room
 
 ```php
+interface ChatRoomMediator 
+{
+    public function showMessage(User $user, string $message);
+}
+
 // Mediator
 class ChatRoom implements ChatRoomMediator
 {


### PR DESCRIPTION
Noticed that the interface that is implemented by ChatRoom class is missing. Probably done for making more clear which class is the mediator, however that breaks the code.

https://github.com/kamranahmedse/design-patterns-for-humans#-mediator