### PR TITLE
Fix Proxy Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,15 +1220,15 @@ class LabDoor implements Door
     }
 }
 ```
-Then we have a proxy to secure any doors that we want
+Then we expose a proxy for creating secure doors
 ```php
-class Security
+class SecureDoor implements Door
 {
     protected $door;
 
-    public function __construct(Door $door)
+    public function __construct()
     {
-        $this->door = $door;
+        $this->door = new LabDoor();
     }
 
     public function open($password)
@@ -1240,20 +1240,20 @@ class Security
         }
     }
 
-    public function authenticate($password)
-    {
-        return $password === '$ecr@t';
-    }
-
     public function close()
     {
         $this->door->close();
+    }
+    
+    private function authenticate($password)
+    {
+        return $password === '$ecr@t';
     }
 }
 ```
 And here is how it can be used
 ```php
-$door = new Security(new LabDoor());
+$door = new SecureDoor();
 $door->open('invalid'); // Big no! It ain't possible.
 
 $door->open('$ecr@t'); // Opening lab door


### PR DESCRIPTION
The proxy class should be constructed the same way as the class it wraps. From this SO answer: "Proxy and Decorator both have the same interface as their wrapped types, but the proxy creates an instance under the hood, whereas the decorator takes an instance in the constructor." https://stackoverflow.com/a/7211706/2433572

As it stands, the proxy pattern is indistinguishable from the decorator pattern.